### PR TITLE
Allow Chaining of config.setup for Editor Init

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -99,6 +99,9 @@ const TinyMCE = React.createClass({
     // hide the textarea that is me so that no one sees it
     findDOMNode(this).style.hidden = 'hidden';
 
+    var setupCallback = config.setup;
+    var hasSetupCallback = (typeof setupCallback === 'function');
+
     config.selector = '#' + this.id;
     config.setup = (editor) => {
       EVENTS.forEach((event, index) => {
@@ -115,6 +118,9 @@ const TinyMCE = React.createClass({
         editor.on('init', () => {
           editor.setContent(content);
         });
+      }
+      if(hasSetupCallback) {
+        setupCallback(editor);
       }
     };
 


### PR DESCRIPTION
This modifies config use of the setup callback by chaining it after wrapper tasks. The wrapper still uses this setup routine to proxy events and set initial content. We needed the ability to configure custom buttons with callbacks easily defined within our component.

This allows configuration similar to the official [TinyMCE examples](http://www.tinymce.com/tryit/3_x/custom_toolbar_button.php).