### PR TITLE
Fix issues with updating props

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -56,17 +56,20 @@ const TinyMCE = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    if (!isEqual(this.props.config, nextProps.config)) {
-      this._init(nextProps.config, nextProps.content);
-    }
     if (!isEqual(this.props.id, nextProps.id)) {
       this.id = nextProps.id;
+    }
+    if (!isEqual(this.props.config, nextProps.config) || !isEqual(this.props.id, nextProps.id)) {
+      this._init(clone(nextProps.config), nextProps.content);
+      return;
+    }
+    if (!isEqual(this.props.content, nextProps.content)) {
+      tinymce.EditorManager.get(this.id).setContent(nextProps.content);
     }
   },
 
   shouldComponentUpdate(nextProps) {
     return (
-      !isEqual(this.props.content, nextProps.content) ||
       !isEqual(this.props.config, nextProps.config)
     );
   },

--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -64,7 +64,11 @@ const TinyMCE = React.createClass({
       return;
     }
     if (!isEqual(this.props.content, nextProps.content)) {
-      tinymce.EditorManager.get(this.id).setContent(nextProps.content);
+      let editor = tinymce.EditorManager.get(this.id);
+      editor.setContent(nextProps.content);
+
+      editor.selection.select(editor.getBody(), true);
+      editor.selection.collapse(false);
     }
   },
 

--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -63,8 +63,9 @@ const TinyMCE = React.createClass({
       this._init(clone(nextProps.config), nextProps.content);
       return;
     }
-    if (!isEqual(this.props.content, nextProps.content)) {
-      let editor = tinymce.EditorManager.get(this.id);
+
+    const editor = tinymce.EditorManager.get(this.id);
+    if (!isEqual(editor.getContent({format: 'raw'}), nextProps.content)) {
       editor.setContent(nextProps.content);
 
       editor.selection.select(editor.getBody(), true);


### PR DESCRIPTION
- A simple content change was causing a complete re-render
- Altering `id` prop was not initiating re-_init causing a selector mis-match
- Initiating re-_init was not cloning the new props, `_init` was then adding new properties to the non-bound props and triggering false re-renders
