### PR TITLE
Fix an issue, that would cause tinymce to be updated too often

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { findDOMNode } from 'react-dom';
 import isEqual from 'lodash/lang/isEqual';
-import clone from 'lodash/lang/clone';
+import cloneDeep from 'lodash/lang/cloneDeep';
 import uuid from '../helpers/uuid';
 import ucFirst from '../helpers/ucFirst';
 
@@ -51,7 +51,6 @@ const TinyMCE = React.createClass({
   },
 
   componentDidMount() {
-    const config = clone(this.props.config);
     this._init(config);
   },
 
@@ -91,10 +90,14 @@ const TinyMCE = React.createClass({
     );
   },
 
-  _init(config, content) {
+  _init(configProp, content) {
     if (this._isInit) {
       this._remove();
     }
+
+    // Clone the config prop to prevent modifications by TinyMCE, which
+    // would cause the react component to be updated incorrectly.
+    var config = cloneDeep(configProp);
 
     // hide the textarea that is me so that no one sees it
     findDOMNode(this).style.hidden = 'hidden';


### PR DESCRIPTION
If the props have nested elements, the comparison between the existing props and the new props will fail, due to TinyMCE doing modifications on the react component's config prop.

- Improves a previous fix in commit #15
- Fixes issue #26 