### PR TITLE
Support react (and react-dom) 15 as a peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   "author": "Matt Zabriskie",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
     "rackt-cli": "^0.5.3",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0"
   },
   "dependencies": {
     "lodash": "^3.9.3"


### PR DESCRIPTION
  - `^` doesn't work since react moved from `0.14` to `15.0`
  - Continue to support 0.14 as a peer dependency
  - Use 15.0 for dev dependencies