### PR TITLE
use the latest handler passed in by the props

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -105,10 +105,11 @@ const TinyMCE = React.createClass({
     config.selector = '#' + this.id;
     config.setup = (editor) => {
       EVENTS.forEach((event, index) => {
-        const handler = this.props[HANDLER_NAMES[index]];
-        if (typeof handler !== 'function') return;
+        if (!this.props[HANDLER_NAMES[index]]) return;
         editor.on(event, (e) => {
           // native DOM events don't have access to the editor so we pass it here
+          const handler = this.props[HANDLER_NAMES[index]];
+          if (typeof handler !== 'function') return;
           handler(e, editor);
         });
       });


### PR DESCRIPTION
Since the shouldComponentUpdate only checks props.content and props.config, if you change an event handler, the component will still be using the previous handler. A simple fix would be to just always get the latest handler from the props to call instead of using the one stored in the closure. 

Just a suggestion, but it is a bug that I had to address in production.