### PR TITLE
tinymce.4.2.7.min.js Uncaught TypeError: Cannot read property 'body' …

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -52,7 +52,8 @@ const TinyMCE = React.createClass({
 
   componentDidMount() {
     const config = clone(this.props.config);
-    this._init(config);
+    const content = clone(this.props.content);
+    this._init(config,content);
   },
 
   componentWillReceiveProps(nextProps) {
@@ -114,7 +115,7 @@ const TinyMCE = React.createClass({
       });
       // need to set content here because the textarea will still have the
       // old `this.props.content`
-      if (content) {
+      if (typeof content !=="undefined") {
         editor.on('init', () => {
           editor.setContent(content);
         });


### PR DESCRIPTION
issue was in componentDidMount, init was called with one parameter.

I am using react-tinymce 0.2.3 and tinymce 4.2.7. as per below code in handleEditorChange, after call of e.target.getContent() I am getting error

tinymce.4.2.7.min.js:10 Uncaught TypeError: Cannot read property 'body' of null
I tried to put e.target.getContent() in jQuery's ready function but no success.

I am using react 0.13.3.

<TinyMCE config={...} content={html} onBlur={this.handleEditorChange} />
http://stackoverflow.com/questions/38613095/tinymce-4-2-7-min-js-uncaught-typeerror-cannot-read-property-body-of-null
