### PR TITLE
check functions for equality and clone props and content properties

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { findDOMNode } from 'react-dom';
 import isEqual from 'lodash/lang/isEqual';
 import clone from 'lodash/lang/clone';
+import cloneDeep from 'lodash/lang/cloneDeep';
 import uuid from '../helpers/uuid';
 import ucFirst from '../helpers/ucFirst';
 
@@ -51,12 +52,19 @@ const TinyMCE = React.createClass({
   },
 
   componentDidMount() {
-    const config = clone(this.props.config);
-    this._init(config);
+    this._init(this.props.config, this.props.content);
   },
 
   componentWillReceiveProps(nextProps) {
-    if (!isEqual(this.props.config, nextProps.config)) {
+    if (!isEqual(this.props.config, nextProps.config, function(c1, c2) {
+		    if(typeof c1 === 'function' && typeof c2 === 'function') {
+			    return c1.toString() === c2.toString();
+		    }
+		    if(c1.hasOwnProperty('items') && c2.hasOwnProperty('items')) {
+			    return c1.length == c2.length;
+		    }
+	    }))
+    {
       this._init(nextProps.config, nextProps.content);
     }
     if (!isEqual(this.props.id, nextProps.id)) {
@@ -67,7 +75,14 @@ const TinyMCE = React.createClass({
   shouldComponentUpdate(nextProps) {
     return (
       !isEqual(this.props.content, nextProps.content) ||
-      !isEqual(this.props.config, nextProps.config)
+      !isEqual(this.props.config, nextProps.config, function(c1, c2) {
+	      if(typeof c1 === 'function' && typeof c2 === 'function') {
+		      return c1.toString() === c2.toString();
+	      }
+	      if(c1.hasOwnProperty('items') && c2.hasOwnProperty('items')) {
+		      return c1.length == c2.length;
+	      }
+      })
     );
   },
 
@@ -91,10 +106,13 @@ const TinyMCE = React.createClass({
     );
   },
 
-  _init(config, content) {
+  _init(configProp, contentProp) {
     if (this._isInit) {
       this._remove();
     }
+
+    var config = cloneDeep(configProp);
+	var content = clone(contentProp);
 
     // hide the textarea that is me so that no one sees it
     findDOMNode(this).style.hidden = 'hidden';


### PR DESCRIPTION
this will result in much less rerendering and thus less or none cursor jumping