### PR TITLE
Added "name" prop

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -36,7 +36,8 @@ const TinyMCE = React.createClass({
     config: React.PropTypes.object,
     content: React.PropTypes.string,
     id: React.PropTypes.string,
-    className: React.PropTypes.string
+    className: React.PropTypes.string,
+    name: React.PropTypes.string
   },
 
   getDefaultProps() {
@@ -86,6 +87,7 @@ const TinyMCE = React.createClass({
       <textarea
         id={this.id}
         className={this.props.className}
+        name={this.props.name}
         defaultValue={this.props.content}
       />
     );


### PR DESCRIPTION
Simple change—added name property that assigns to textarea. Is especially useful for .NET Core's input to model binding which relies on both the element's id and name.