### PR TITLE
Change lodash dependency to >=4.0

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { findDOMNode } from 'react-dom';
-import isEqual from 'lodash/lang/isEqual';
-import clone from 'lodash/lang/clone';
+import isEqual from 'lodash/isEqual';
+import clone from 'lodash/clone';
 import uuid from '../helpers/uuid';
 import ucFirst from '../helpers/ucFirst';
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "react-dom": "^15.0.0"
   },
   "dependencies": {
-    "lodash": "^3.9.3"
+    "lodash": ">=4.0.0"
   }
 }


### PR DESCRIPTION
We have a lot of projects that are consuming this
that are already loading lodash 4.x for other dependencies.
Having this 3.x dependency here was causing us to load a 
separate lodash onto the page just for this.

By bumping this to 4.x+ it will use the same lodash
that everything else on the page is already using