### PR TITLE
tried to fix the rerender issue on props change

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -71,6 +71,12 @@ const TinyMCE = React.createClass({
     //   editor.selection.select(editor.getBody(), true);
     //   editor.selection.collapse(false);
     // }
+
+    // TODO: This works better for me, not sure if it's the correct solution
+    const editor = tinymce.EditorManager.get(this.id);
+    if (editor && !isEqual(editor.getContent(), nextProps.content)) {
+      editor.setContent(nextProps.content);
+    }
   },
 
   shouldComponentUpdate(nextProps) {


### PR DESCRIPTION
I was getting an issue with your fix, that everytime I pressed enter in my Editor, I was getting this error in my console.

`Uncaught TypeError: Cannot read property 'appendChild' of null`

While with my fix, things seems to be working better

