### PR TITLE
fix chrome performance

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -95,6 +95,7 @@ const TinyMCE = createReactClass({
     ) : (
       <textarea
         id={this.id}
+        hidden="true"
         className={this.props.className}
         name={this.props.name}
         defaultValue={this.props.content}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tinymce",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "React TinyMCE component",
   "main": "lib/main.js",
   "scripts": {


### PR DESCRIPTION
Chrome suffers badly with performance if rendering a large amount of html into tinymce such as used in base64 encoded images. Hiding the textarea with the 'hidden' attribute fixes this issue.